### PR TITLE
Update installation instruction for global use

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You need to have Rust and Nmap installed in your computer, then run:
 2. cargo build --release
 # Now the binary is in ./target/release/unimap
 3. cp ./target/release/unimap /usr/local/bin
-# copy the unimap binaries for run from everywhere
+# Now you can use the `unimap` command from everyewhere.
 ```
 
 ## Using precompiled binaries

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You need to have Rust and Nmap installed in your computer, then run:
 # Now the binary is in ./target/release/unimap
 3. cp ./target/release/unimap /usr/local/bin
 # Now you can use the `unimap` command from everyewhere.
+# This command only suuport Linux and MacOS. Windows user need specify the target path in environment variable
 ```
 
 ## Using precompiled binaries

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You need to have Rust and Nmap installed in your computer, then run:
 # extract it and continue to next step.
 2. cargo build --release
 # Now the binary is in ./target/release/unimap
+# The next command only works on Linux and MacOS. Windows user need specify the target path in environment variable
 3. cp ./target/release/unimap /usr/local/bin
 # Now you can use the `unimap` command from everyewhere.
-# This command only suuport Linux and MacOS. Windows user need specify the target path in environment variable
 ```
 
 ## Using precompiled binaries

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You need to have Rust and Nmap installed in your computer, then run:
 # extract it and continue to next step.
 2. cargo build --release
 # Now the binary is in ./target/release/unimap
+3. cp ./target/release/unimap /usr/local/bin
+# copy the unimap binaries for run from everywhere
 ```
 
 ## Using precompiled binaries


### PR DESCRIPTION
Updated the installation for global use by a normal user of the machine, because pre-built binary from the releases causes error while running unimap.

If the user compiled and follow the instruction they can use just type the command `$ unimap`.