### PR TITLE
Docker support for unimap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:alpine as builder
+RUN apk add --no-cache build-base
+
+WORKDIR /usr/src/unimap
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+RUN cargo install --path .
+
+FROM alpine:3.12
+
+RUN apk add --no-cache nmap nmap-scripts wget
+COPY --from=builder /usr/local/cargo/bin/unimap /usr/local/bin/unimap
+
+ENTRYPOINT [ "/usr/local/bin/unimap" ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ You need to have Rust and Nmap installed in your computer, then run:
 # Now you can use the `unimap` command from everyewhere.
 ```
 
+## Docker support
+
+```
+1. git clone https://github.com/Edu4rdSHL/unimap.git && cd unimap
+2. docker build --tag unimap .
+3. docker run -it --rm --name unimap unimap -t hackerone.com --fast-scan
+# Set alias in ~/.bashrc or ~/.zshrc for global use
+4. alias unimap='docker run -it --rm --name unimap unimap'
+```
+
 ## Using precompiled binaries
 
 Download the [latest version](https://github.com/Edu4rdSHL/unimap/releases/latest) for your OS and use it.


### PR DESCRIPTION
I was working around unimap and thought it will be a good idea to create PR for Docker support of unimap. So, I just jumped into it and created docker support for unimap.

You may push docker image to **Docker Hub** after this merge, so the users don't need to clone this repository to compile the docker image and use it.

The docker image will be less than 40MB.

![docker image size](https://i.imgur.com/soWNrdj.png)

Instructions added in README.md with the heading **"Docker support"**. A screenshot added below for clarification.

![docker support for unimap](https://i.imgur.com/c3i0n8m.png)

