### PR TITLE
fix: correct sucessfully to successfully typo in echo message

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -88,7 +88,7 @@ fi
 echo "Creating manpage..."
 if command -v help2man >/dev/null; then
   if help2man -o "$MANPAGE_DIR" "target/$LINUX_TARGET/release/$NAME"; then
-    echo "Manpage created sucessfully and saved in $MANPAGE_DIR"
+    echo "Manpage created successfully and saved in $MANPAGE_DIR"
   else
     echo "Error creating manpage."
   fi


### PR DESCRIPTION
Fix typo: sucessfully to successfully in builder.sh (line 91).

User-visible echo message displayed after manpage creation.

Changes:
- 1 file, 1 line change